### PR TITLE
Fixed compose fetching

### DIFF
--- a/main.py
+++ b/main.py
@@ -282,11 +282,19 @@ if __name__ == '__main__':
 				build_actions = build_info['actions']
 				component = [action['text'] for action in build_actions if 'COMPONENT' in action.get('text', '')]
 
-			compose = [action['text'][13:-4] for action in build_actions if 'core_puddle' in action.get('text', '')][0]
+			compose = [action['text'][13:-4] for action in build_actions if 'core_puddle' in action.get('text', '')]
+
+			# No compose could be found; likely a failed job where the 'core_puddle' var was never calculated
+			if compose == []:
+				compose = "Could not find compose"
+			else:
+				compose = compose[0]
+
 			lcb_url = build_info['url']
 			lcb_result = build_info['result']
 
 		except Exception as e:
+
 			# No "Last Completed Build" found
 			if job_info['builds'] == []:
 				lcb_num = None
@@ -296,7 +304,7 @@ if __name__ == '__main__':
 
 			# Unknown error, skip job
 			else:
-				print("Jenkins API call error: ", e)
+				print("Jenkins API call error on job {}: {}".format(job_name, e))
 				continue
 
 		# take action based on last completed build result

--- a/template.html
+++ b/template.html
@@ -38,9 +38,13 @@
 					<td style="text-align: center;">{{row.compose}}</td>
 					<td style="text-align: center;" bgcolor="#ef2929">{{row.lcb_result}}</td>
 
-				<!-- LCB is set to any other state -->
+				<!-- LCB is set to any other state ('NO_KNOWN_BUILDS', 'ERROR') -->
 				{% else %}
-					<td style="text-align: center;">{{row.lcb_num}}</td>
+					{% if row.lcb_url != None %}
+						<td style="text-align: center;"><a href="{{row.lcb_url}}">{{row.lcb_num}}</a></td>
+					{% else %}
+						<td style="text-align: center;">{{row.lcb_num}}</td>
+					{% endif %}
 					<td style="text-align: center;">{{row.compose}}</td>
 					<td style="text-align: center;" bgcolor="#808080">{{row.lcb_result}}</td>
 				{% endif %}


### PR DESCRIPTION
Fixes #77 

Also added additional error handling:
- 'ERROR' entries now include link to build number if relevant 
- 'Jenkins API call error' block now logs 'job_name' where error occured