### PR TITLE
Modifies the shebang

### DIFF
--- a/jeeves.py
+++ b/jeeves.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 import os
 import sys


### PR DESCRIPTION
Hardwriting the path to the python3 executable provided issues when
installing Jeeves insie a virtualenv, and executing `./jeeves.py`.

By calling `env python` we're making sure to select the proper
executable even when using virtualenv