### PR TITLE
Add an option to specify a different template

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,14 +35,16 @@ You can define "owners" for a job in "blockers.yaml" for use with reminder mode.
 
 ## Usage
 To run:
-- `$ ./jeeves.py [-h] [--config CONFIG] [--blockers BLOCKERS] [--no-email] [--test-email] [--remind]`
+- `$ ./jeeves.py [-h] [--config CONFIG] [--blockers BLOCKERS] [--no-email] [--test-email] [--remind] [--template TEMPLATE]`
 - To only save report to the 'archive' folder, and not send an email, add `--no-email`
 - To send report to email specified in `email_to_test` field, add `--test-email`
 	- Note that running Jeeves with the `--test-email` flag will not save the report to 'archive' folder
 	- As such, running Jeeves with both the `--test-email` and `--no-email` flags will result in no report being saved and no email being sent
 - To run Jeeves in "reminder" mode, add `--remind`
     - Note this will override the usage of both `--no-email` and `--test-email`
-
+- To use a different template for HTML report, add `--template <template file>`.  The template should be in the templates directory.
+    - Note that this flag will be ignored if Jeeves is run in "reminder" mode
+	
 #### Reminder Mode
 Jeeves has a reminder mode that will send an email to "owners" of jobs in Jenkins that have "UNSTABLE" or "FAILURE" status. You can add as many "owners" as you would like to a given job. You can see some examples of this in "blockers.yaml.example". 
 

--- a/jeeves.py
+++ b/jeeves.py
@@ -22,12 +22,14 @@ if __name__ == '__main__':
 	parser.add_argument("--no-email", default=False, action='store_true', help='Flag to not send an email of the report')
 	parser.add_argument("--test-email", default=False, action='store_true', help='Flag to send email to test address')
 	parser.add_argument("--remind", default=False, action='store_true', help='Flag to run Jeeves in "reminder" mode. Note this will override --no-email and --save')
+	parser.add_argument("--template", default="report_template.html", type=str, help='The template file under templates directory to use for the HTML report')
 	args = parser.parse_args()
 	config_file = args.config
 	blocker_file = args.blockers
 	test_email = args.test_email
 	no_email = args.no_email
 	remind_flag = args.remind
+	template_file = args.template
 
 	# load configuration data - if YAML format is invalid, log and end program execution
 	try:
@@ -62,4 +64,4 @@ if __name__ == '__main__':
 		run_remind(config, blockers, server, header)
 	else:
 		header = generate_header(user, config['job_search_fields'])
-		run_report(config, blockers, server, header, test_email, no_email)
+		run_report(config, blockers, server, header, test_email, no_email, template_file)

--- a/report.py
+++ b/report.py
@@ -1,5 +1,6 @@
 import json
 import jinja2
+import sys
 
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -11,7 +12,7 @@ from functions import generate_html_file, get_bugs_dict, \
 	get_other_blockers, percent
 
 
-def run_report(config, blockers, server, header, test_email, no_email):
+def run_report(config, blockers, server, header, test_email, no_email, template_file):
 
 	# fetch all relevant jobs
 	jobs = get_jenkins_jobs(server, config['job_search_fields'])
@@ -195,7 +196,11 @@ def run_report(config, blockers, server, header, test_email, no_email):
 	# initialize jinja2 vars
 	loader = jinja2.FileSystemLoader('./templates')
 	env = jinja2.Environment(loader=loader)
-	template = env.get_template('report_template.html')
+	try:
+		template = env.get_template(template_file)
+	except Exception as e:
+		print("Error loading template file: {}\n{}".format(template_file, e))
+		sys.exit()
 
 	# generate HTML report
 	htmlcode = template.render(


### PR DESCRIPTION
Add an option to specify a different template than the default report_template.html.
The template should be under the templates directory.
Closes #143 