### PR TITLE
Reworked how blocker data is displayed in reports and reminders

### DIFF
--- a/jeeves.py
+++ b/jeeves.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
 	parser.add_argument("--blockers", default="blockers.yaml", type=str, help='Blockers YAML file to use')
 	parser.add_argument("--no-email", default=False, action='store_true', help='Flag to not send an email of the report')
 	parser.add_argument("--test-email", default=False, action='store_true', help='Flag to send email to test address')
-	parser.add_argument("--remind", default=False, action='store_true', help='Flag to run Jeeves in "reminder" mode. Note this will override --no-email and --save')
+	parser.add_argument("--remind", default=False, action='store_true', help='Flag to run Jeeves in "reminder" mode. Note this will override --no-email and --test-email')
 	parser.add_argument("--template", default="report_template.html", type=str, help='The template file under templates directory to use for the HTML report')
 	args = parser.parse_args()
 	config_file = args.config

--- a/remind.py
+++ b/remind.py
@@ -41,30 +41,42 @@ def run_remind(config, blockers, server, header):
 			# if jeeves was unable to collect any good jenkins API info, skip job
 			if jenkins_api_info:
 
-				# only care about jobs with UNSTABLE or FAILURE status
-				if jenkins_api_info['lcb_result'] == "UNSTABLE" or jenkins_api_info['lcb_result'] == "FAILURE":
+				# only care about jobs without SUCCESS status
+				if jenkins_api_info['lcb_result'] != "SUCCESS":
 
 					# get all related bugs to job
 					try:
 						bug_ids = blockers[job_name]['bz']
+						if 0 in bug_ids:
+							bug_ids.remove(0)
 						bugs_dict = get_bugs_dict(bug_ids, config)
 						bugs = list(map(bugs_dict.get, bug_ids))
-					except:
-						bugs = [{'bug_name': "Could not find relevant bug", 'bug_url': None}]
+					except Exception as e:
+						print("Error fetching bugs for job {}: {}".format(job_name, e))
+						bugs = []
 
 					# get all related tickets to job
 					try:
 						ticket_ids = blockers[job_name]['jira']
+						if 0 in ticket_ids:
+							ticket_ids.remove(0)
 						tickets_dict = get_jira_dict(ticket_ids, config)
 						tickets = list(map(tickets_dict.get, ticket_ids))
-					except:
-						tickets = [{'ticket_name': "Could not find relevant ticket", 'ticket_url': None}]
+					except Exception as e:
+						print("Error fetching ticket for job {}: {}".format(job_name, e))
+						tickets = []
 
 					# get any "other" artifact for job
 					try:
 						other = get_other_blockers(blockers, job_name)
-					except:
-						other = [{'other_name': 'N/A', 'other_url': None}]
+					except Exception as e:
+						print("Error fetching other blockers for job {}: {}".format(job_name, e))
+						other = []
+
+					# check if row contains any valid blockers for reporting
+					blocker_bool = True
+					if (len(bugs) == 0) and (len(tickets) == 0) and (len(other) == 0):
+						blocker_bool = False
 
 					# build row
 					row = {
@@ -76,6 +88,7 @@ def run_remind(config, blockers, server, header):
 						'lcb_url': jenkins_api_info['lcb_url'],
 						'compose': jenkins_api_info['compose'],
 						'lcb_result': jenkins_api_info['lcb_result'],
+						'blocker_bool': blocker_bool,
 						'bugs': bugs,
 						'tickets': tickets,
 						'other': other
@@ -84,8 +97,11 @@ def run_remind(config, blockers, server, header):
 					# append row to rows
 					rows.append(row)
 
-		# if no rows were generated, owner has no jobs that were UNSTABLE or FAILED
+		# if no rows were generated, owner has all passing jobs
 		if rows != []:
+
+			# sort rows by descending OSP version
+			rows = sorted(rows, key=lambda row: row['osp_version'], reverse=True)
 
 			# initialize jinja2 vars
 			loader = jinja2.FileSystemLoader('./templates')
@@ -129,4 +145,4 @@ def run_remind(config, blockers, server, header):
 				generate_html_file(htmlcode, remind=True)
 
 		else:
-			print("Owner {} has no UNSTABLE or FAILED jobs!".format(owner))
+			print("Owner {} has all passing jobs!".format(owner))

--- a/report.py
+++ b/report.py
@@ -33,7 +33,7 @@ def run_report(config, blockers, server, header, test_email, no_email, template_
 	all_tickets_set = get_jira_set(blockers) if blockers else {}
 
 	# Create dictionary from the set of all jira tickets with ticket id as key and name and link as value
-	all_jira_dict = get_jira_dict(all_tickets_set, config)
+	all_tickets_dict = get_jira_dict(all_tickets_set, config)
 
 	# iterate through all relevant jobs and build report rows
 	num_success = 0
@@ -63,53 +63,63 @@ def run_report(config, blockers, server, header, test_email, no_email, template_
 		if jenkins_api_info:
 
 			# take action based on last completed build result
-			if jenkins_api_info['lcb_result'] in ["SUCCESS", "NO_KNOWN_BUILDS", "ABORTED"]:
-				if jenkins_api_info['lcb_result'] == "SUCCESS":
-					num_success += 1
-				elif jenkins_api_info['lcb_result'] == "NO_KNOWN_BUILDS":
-					num_missing += 1
-				else:
-					num_aborted += 1
+			if jenkins_api_info['lcb_result'] == "SUCCESS":
+				num_success += 1
+				bugs = []
+				tickets = []
+				other = []
 
-				bugs = [{'bug_name': 'N/A', 'bug_url': None}]
-				tickets = [{'ticket_name': 'N/A', 'ticket_url': None}]
-				other = [{'other_name': 'N/A', 'other_url': None}]
-
-			elif jenkins_api_info['lcb_result'] in ["UNSTABLE", "FAILURE"]:
+			elif jenkins_api_info['lcb_result'] in ["UNSTABLE", "FAILURE", "ABORTED", "NO_KNOWN_BUILDS"]:
 				if jenkins_api_info['lcb_result'] == "UNSTABLE":
 					num_unstable += 1
-				else:
+				elif jenkins_api_info['lcb_result'] == "FAILURE":
 					num_failure += 1
+				elif jenkins_api_info['lcb_result'] == "ABORTED":
+					num_aborted += 1
+				else:
+					num_missing += 1
 
 				# get all related bugs to job
 				try:
 					bug_ids = blockers[job_name]['bz']
+					if 0 in bug_ids:
+						bug_ids.remove(0)
 					all_bugs.extend(bug_ids)
 					bugs = list(map(all_bugs_dict.get, bug_ids))
-				except:
-					bugs = [{'bug_name': "Could not find relevant bug", 'bug_url': None}]
+				except Exception as e:
+					print("Error fetching bugs for job {}: {}".format(job_name, e))
+					bugs = []
 
 				# get all related tickets to job
 				try:
 					ticket_ids = blockers[job_name]['jira']
+					if 0 in ticket_ids:
+						ticket_ids.remove(0)
 					all_tickets.extend(ticket_ids)
-					tickets = list(map(all_jira_dict.get, ticket_ids))
-				except:
-					tickets = [{'ticket_name': "Could not find relevant ticket", 'ticket_url': None}]
+					tickets = list(map(all_tickets_dict.get, ticket_ids))
+				except Exception as e:
+					print("Error fetching ticket for job {}: {}".format(job_name, e))
+					tickets = []
 
 				# get any "other" artifact for job
 				try:
 					other = get_other_blockers(blockers, job_name)
-				except:
-					other = [{'other_name': 'N/A', 'other_url': None}]
+				except Exception as e:
+					print("Error fetching other blockers for job {}: {}".format(job_name, e))
+					other = []
 
 			else:
 				print("job {} had lcb_result {}: reporting as error job".format(job_name, jenkins_api_info['lcb_result']))
 				jenkins_api_info['lcb_result'] = "ERROR"
 				num_error += 1
-				bugs = [{'bug_name': 'N/A', 'bug_url': None}]
-				tickets = [{'ticket_name': 'N/A', 'ticket_url': None}]
-				other = [{'other_name': 'N/A', 'other_url': None}]
+				bugs = []
+				tickets = []
+				other = []
+
+			# check if row contains any valid blockers for reporting
+			blocker_bool = True
+			if (len(bugs) == 0) and (len(tickets) == 0) and (len(other) == 0):
+				blocker_bool = False
 
 			# build row
 			row = {
@@ -121,6 +131,7 @@ def run_report(config, blockers, server, header, test_email, no_email, template_
 				'lcb_url': jenkins_api_info['lcb_url'],
 				'compose': jenkins_api_info['compose'],
 				'lcb_result': jenkins_api_info['lcb_result'],
+				'blocker_bool': blocker_bool,
 				'bugs': bugs,
 				'tickets': tickets,
 				'other': other
@@ -150,10 +161,10 @@ def run_report(config, blockers, server, header, test_email, no_email, template_
 	chart_config = {
 		'type': 'pie',
 		'data': {
-			'labels': ['Success', 'Unstable', 'Failed', 'Aborted', 'Error', 'Missing'],
+			'labels': ['Success', 'Unstable', 'Failed', 'Aborted', 'Missing', 'Error'],
 			'datasets': [{
-				'backgroundColor': ['green', 'yellow', 'red', 'grey', 'brown', 'purple'],
-				'data': [num_success, num_unstable, num_failure, num_aborted, num_error, num_missing]
+				'backgroundColor': ['blue', 'yellow', 'red', 'black', 'grey', 'brown'],
+				'data': [num_success, num_unstable, num_failure, num_aborted, num_missing, num_error]
 			}]
 		}
 	}
@@ -176,17 +187,17 @@ def run_report(config, blockers, server, header, test_email, no_email, template_
 		unique_tickets = set(all_tickets)
 		summary['total_tickets'] = "Blocker Tickets: {} total, {} unique".format(len(all_tickets), len(unique_tickets))
 
-	# include missing report if needed
-	if num_missing > 0:
-		summary['total_missing'] = "Total NO_KNOWN_BUILDS:  {}/{} = {}%".format(num_missing, num_jobs, percent(num_missing, num_jobs))
-	else:
-		summary['total_missing'] = False
-
 	# include abort report if needed
 	if num_aborted > 0:
 		summary['total_aborted'] = "Total ABORTED:  {}/{} = {}%".format(num_aborted, num_jobs, percent(num_aborted, num_jobs))
 	else:
 		summary['total_aborted'] = False
+
+	# include missing report if needed
+	if num_missing > 0:
+		summary['total_missing'] = "Total NO_KNOWN_BUILDS:  {}/{} = {}%".format(num_missing, num_jobs, percent(num_missing, num_jobs))
+	else:
+		summary['total_missing'] = False
 
 	# include error report if needed
 	if num_error > 0:

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,34 +1,44 @@
 {% macro blockers(row) %}
-	<p style="text-align: center;"><b>Bugs</b></p>
-	{% for bug in row.bugs %}
-		<ul>
-		{% if bug.bug_url != None %}
-			<li><a href="{{bug.bug_url}}">{{bug.bug_name}}</a></li>
-		{% else %}
-			<li>{{bug.bug_name}}</li>
+	{% if row.bugs|length > 0 %}
+		<p style="text-align: center;"><b>Bugs</b></p>
+		{% for bug in row.bugs %}
+			<ul>
+			{% if bug.bug_url != None %}
+				<li><a href="{{bug.bug_url}}">{{bug.bug_name}}</a></li>
+			{% else %}
+				<li>{{bug.bug_name}}</li>
+			{% endif %}
+			</ul>
+		{% endfor %}
+		{% if row.tickets|length > 0 or row.other|length > 0%}
+			<hr>
 		{% endif %}
-		</ul>
-	{% endfor %}
-	<hr>
-	<p style="text-align: center;"><b>Tickets</b></p>
-	{% for ticket in row.tickets %}
-		<ul>
-		{% if ticket.ticket_url != None %}
-			<li><a href="{{ticket.ticket_url}}">{{ticket.ticket_name}}</a></li>
-		{% else %}
-			<li>{{ticket.ticket_name}}</li>
+	{% endif %}
+	{% if row.tickets|length > 0 %}
+		<p style="text-align: center;"><b>Tickets</b></p>
+		{% for ticket in row.tickets %}
+			<ul>
+			{% if ticket.ticket_url != None %}
+				<li><a href="{{ticket.ticket_url}}">{{ticket.ticket_name}}</a></li>
+			{% else %}
+				<li>{{ticket.ticket_name}}</li>
+			{% endif %}
+			</ul>
+		{% endfor %}
+		{% if row.other|length > 0%}
+			<hr>
 		{% endif %}
-		</ul>
-	{% endfor %}
-	<hr>
-	<p style="text-align: center;"><b>Other</b></p>
-	{% for other in row.other %}
-		<ul>
-		{% if other.other_url != None %}
-			<li><a href="{{other.other_url}}">{{other.other_name}}</a></li>
-		{% else %}
-			<li>{{other.other_name}}</li>
-		{% endif %}
-		</ul>
-	{% endfor %}
+	{% endif %}
+	{% if row.other|length > 0 %}
+		<p style="text-align: center;"><b>Other</b></p>
+		{% for other in row.other %}
+			<ul>
+			{% if other.other_url != None %}
+				<li><a href="{{other.other_url}}">{{other.other_name}}</a></li>
+			{% else %}
+				<li>{{other.other_name}}</li>
+			{% endif %}
+			</ul>
+		{% endfor %}
+	{% endif %}
 {% endmacro %}

--- a/templates/remind_template.html
+++ b/templates/remind_template.html
@@ -32,10 +32,12 @@
 							<td style="text-align: center;"><a href="{{row.lcb_url}}">{{row.lcb_num}}</a></td>
 							<td style="text-align: center;">{{row.build_days_ago}}</td>
 							<td style="text-align: center;">{{row.compose}}</td>
-							<td style="text-align: center;" bgcolor="#fdd500">{{row.lcb_result}}</td>
-							<td>
-								{{ blockers(row) }}
-							</td>
+							<td style="text-align: center;" bgcolor="#ffb738">{{row.lcb_result}}</td>
+							{% if row.blocker_bool == False %}
+								<td style="text-align: center;">No blockers have been filed for this job</td>
+							{% else %}
+								<td>{{ blockers(row) }}</td>
+							{% endif %}
 
 						<!-- LCB is "FAILURE" -->
 						{% elif row.lcb_result == "FAILURE" %}
@@ -43,11 +45,13 @@
 							<td style="text-align: center;">{{row.build_days_ago}}</td>
 							<td style="text-align: center;">{{row.compose}}</td>
 							<td style="text-align: center;" bgcolor="#ef2929">{{row.lcb_result}}</td>
-							<td>
-								{{ blockers(row) }}
-							</td>
+							{% if row.blocker_bool == False %}
+								<td style="text-align: center;">No blockers have been filed for this job</td>
+							{% else %}
+								<td>{{ blockers(row) }}</td>
+							{% endif %}
 
-						<!-- LCB is set to any other state ('NO_KNOWN_BUILDS', 'ERROR') -->
+						<!-- LCB is set to any other state ('ABORTED', 'NO_KNOWN_BUILDS', 'ERROR') -->
 						{% else %}
 							{% if row.lcb_url != None %}
 								<td style="text-align: center;"><a href="{{row.lcb_url}}">{{row.lcb_num}}</a></td>
@@ -56,8 +60,19 @@
 							{% endif %}
 							<td style="text-align: center;">{{row.build_days_ago}}</td>
 							<td style="text-align: center;">{{row.compose}}</td>
-							<td style="text-align: center;" bgcolor="#808080">{{row.lcb_result}}</td>
-							<td style="text-align: center;"><p>N/A</p></td>
+							{% if row.lcb_result == "ABORTED" %}
+								<td style="text-align: center;" bgcolor="#515151">{{row.lcb_result}}</td>
+							{% elif row.lcb_result == "NO_KNOWN_BUILDS" %}
+								<td style="text-align: center;" bgcolor="#bbbbbb">{{row.lcb_result}}</td>
+							{% else %}
+								<td style="text-align: center;" bgcolor="#704426">{{row.lcb_result}}</td>
+							{% endif %}
+							{% if row.blocker_bool == False %}
+								<td style="text-align: center;">No blockers have been filed for this job</td>
+							{% else %}
+								<td>{{ blockers(row) }}</td>
+							{% endif %}
+
 						{% endif %}
 					</tr>
 					{% endfor %}

--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -55,12 +55,13 @@
 						<td style="text-align: center;">{{row.osp_version}}</td>
 						<td style="text-align: left;"><a href="{{row.job_url}}">{{row.job_name}}</a></td>
 						<!-- remaining columns (LCB Num, Compose, Result, Blockers) all dependent on result value -->
+
 						<!-- LCB is "SUCCESS" -->
 						{% if row.lcb_result == "SUCCESS" %}
 							<td style="text-align: center;"><a href="{{row.lcb_url}}">{{row.lcb_num}}</a></td>
 							<td style="text-align: center;">{{row.build_days_ago}}</td>
 							<td style="text-align: center;">{{row.compose}}</td>
-							<td style="text-align: center;" bgcolor="#4646ff"><a href="https://www.youtube.com/watch?v=68ugkg9RePc" style="text-decoration: none; color: #000;">{{row.lcb_result}}</a></td>
+							<td style="text-align: center;" bgcolor="#3465a4"><a href="https://www.youtube.com/watch?v=68ugkg9RePc" style="text-decoration: none; color: #000;">{{row.lcb_result}}</a></td>
 							<td style="text-align: center;"><p>N/A</p></td>
 
 						<!-- LCB is "UNSTABLE" -->
@@ -68,8 +69,12 @@
 							<td style="text-align: center;"><a href="{{row.lcb_url}}">{{row.lcb_num}}</a></td>
 							<td style="text-align: center;">{{row.build_days_ago}}</td>
 							<td style="text-align: center;">{{row.compose}}</td>
-							<td style="text-align: center;" bgcolor="#fdd500">{{row.lcb_result}}</td>
-							<td>{{ blockers(row) }}</td>
+							<td style="text-align: center;" bgcolor="#ffb738">{{row.lcb_result}}</td>
+							{% if row.blocker_bool == False %}
+								<td style="text-align: center;">No blockers have been filed for this job</td>
+							{% else %}
+								<td>{{ blockers(row) }}</td>
+							{% endif %}
 
 						<!-- LCB is "FAILURE" -->
 						{% elif row.lcb_result == "FAILURE" %}
@@ -77,9 +82,13 @@
 							<td style="text-align: center;">{{row.build_days_ago}}</td>
 							<td style="text-align: center;">{{row.compose}}</td>
 							<td style="text-align: center;" bgcolor="#ef2929">{{row.lcb_result}}</td>
-							<td>{{ blockers(row) }}</td>
-
-						<!-- LCB is set to any other state ('NO_KNOWN_BUILDS', 'ERROR') -->
+							{% if row.blocker_bool == False %}
+								<td style="text-align: center;">No blockers have been filed for this job</td>
+							{% else %}
+								<td>{{ blockers(row) }}</td>
+							{% endif %}
+							
+						<!-- LCB is set to any other state ('ABORTED', 'NO_KNOWN_BUILDS', 'ERROR') -->
 						{% else %}
 							{% if row.lcb_url != None %}
 								<td style="text-align: center;"><a href="{{row.lcb_url}}">{{row.lcb_num}}</a></td>
@@ -88,8 +97,18 @@
 							{% endif %}
 							<td style="text-align: center;">{{row.build_days_ago}}</td>
 							<td style="text-align: center;">{{row.compose}}</td>
-							<td style="text-align: center;" bgcolor="#808080">{{row.lcb_result}}</td>
-							<td style="text-align: center;"><p>N/A</p></td>
+							{% if row.lcb_result == "ABORTED" %}
+								<td style="text-align: center;" bgcolor="#515151">{{row.lcb_result}}</td>
+							{% elif row.lcb_result == "NO_KNOWN_BUILDS" %}
+								<td style="text-align: center;" bgcolor="#bbbbbb">{{row.lcb_result}}</td>
+							{% else %}
+								<td style="text-align: center;" bgcolor="#704426">{{row.lcb_result}}</td>
+							{% endif %}
+							{% if row.blocker_bool == False %}
+								<td style="text-align: center;">No blockers have been filed for this job</td>
+							{% else %}
+								<td>{{ blockers(row) }}</td>
+							{% endif %}
 
 						{% endif %}
 					</tr>

--- a/test_functions.py
+++ b/test_functions.py
@@ -19,7 +19,7 @@ def test_get_bugs_set():
 		'job2': {'bz': [123456]},
 		'job3': {'bz': [123456, 789123]}
 	}
-	assert get_bugs_set(mockers) == {0, 123456, 789123}
+	assert get_bugs_set(mockers) == {123456, 789123}
 
 
 def test_get_jenkins_job_info():
@@ -40,7 +40,7 @@ def test_get_jira_set():
 		'job2': {'jira': ['RHOSINFRA-123']},
 		'job3': {'jira': ['RHOSINFRA-123', 'RHOSENTDFG-456']}
 	}
-	assert get_jira_set(mockers) == {0, 'RHOSINFRA-123', 'RHOSENTDFG-456'}
+	assert get_jira_set(mockers) == {'RHOSINFRA-123', 'RHOSENTDFG-456'}
 
 
 def test_get_osp_version():


### PR DESCRIPTION
Fixes #140 

This is a larger change, so here are some high-level details:
- As per the README, the integer value of 0 is used as a "placeholder" value in `blockers.yaml` for jobs that have no active blockers filed either as bugs or tickets.
- Previously, whether or not the value was present in a non-passing job was used to make a determination between a "triaged" job (failing but 0 value is present) and a "non-triaged" job (job not present in blockers file). This distinction was previously used in the reporting, but is no longer made.
- Rather, the logic has been retooled so that the 0 value is scrubbed from blocker files and rather a calculation is made as to whether or not a job has **any** blockers filed, and have adjusted the reporting accordingly. Note that 0 can and should still be used as a placeholder value for job blockers.
- Also made some minor changes in colors used for LCB result in both the chart and table