### PR TITLE
Added ability to inject preamble into reports

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,10 +34,10 @@ If you have a blocker for a job that is neither a Bugzilla bug or a Jira ticket,
 If you wish to use a different blockers file, you can specify it as a command line argument.
 
 #### Tracking Owners
-You can define "owners" for a job in `blockers.yaml` for use with reminder mode. To do so, simply add an "owners" subfield to a job with one or more emails. You can see some examples of this in `blockers.yaml.example` 
+You can define "owners" for a job in `blockers.yaml` for use with reminder mode. To do so, simply add an "owners" subfield to a job with one or more emails. You can see some examples of this in `blockers.yaml.example`
 
 ## Usage
-`$ ./jeeves.py [-h] [--config CONFIG] [--blockers BLOCKERS] [--no-email] [--test-email] [--remind] [--template TEMPLATE]`
+`$ ./jeeves.py [-h] [--config CONFIG] [--blockers BLOCKERS] [--preamble PREAMBLE] [--no-email] [--test-email] [--remind] [--template TEMPLATE]`
 
 For a base run, simply run `$ ./jeeves.py` using the `--config` and `--blocker` flags if needed as detailed above. For details on the additional flags avaliable see below:
 - To only save report to the 'archive' folder, and not send an email, add `--no-email`
@@ -47,6 +47,8 @@ For a base run, simply run `$ ./jeeves.py` using the `--config` and `--blocker` 
 - To run Jeeves in "reminder" mode, add `--remind`
     - Note this will override the usage of both `--no-email` and `--test-email`
 - To use a different template for HTML report, add `--template <template file>`.  The template should be in the templates directory.
+    - Note that this flag will be ignored if Jeeves is run in "reminder" mode
+- To add a "preamble" to the report, add `--preamble <preamble file>`. The file should be written in HTML.
     - Note that this flag will be ignored if Jeeves is run in "reminder" mode
 
 #### Filtering Builds

--- a/jeeves.py
+++ b/jeeves.py
@@ -19,6 +19,7 @@ if __name__ == '__main__':
 	parser = argparse.ArgumentParser(description='An automated report generator for Jenkins CI')
 	parser.add_argument("--config", default="config.yaml", type=str, help='Configuration YAML file to use')
 	parser.add_argument("--blockers", default="blockers.yaml", type=str, help='Blockers YAML file to use')
+	parser.add_argument("--preamble", default=False, type=str, help='Preamble HTML file to use')
 	parser.add_argument("--no-email", default=False, action='store_true', help='Flag to not send an email of the report')
 	parser.add_argument("--test-email", default=False, action='store_true', help='Flag to send email to test address')
 	parser.add_argument("--remind", default=False, action='store_true', help='Flag to run Jeeves in "reminder" mode. Note this will override --no-email and --test-email')
@@ -26,6 +27,7 @@ if __name__ == '__main__':
 	args = parser.parse_args()
 	config_file = args.config
 	blocker_file = args.blockers
+	preamble_file = args.preamble
 	test_email = args.test_email
 	no_email = args.no_email
 	remind_flag = args.remind
@@ -68,4 +70,4 @@ if __name__ == '__main__':
 		run_remind(config, blockers, server, header)
 	else:
 		header = generate_header(user, config['job_search_fields'], filter_param_name=fpn, filter_param_value=fpv)
-		run_report(config, blockers, server, header, test_email, no_email, template_file)
+		run_report(config, blockers, preamble_file, server, header, test_email, no_email, template_file)

--- a/report.py
+++ b/report.py
@@ -12,7 +12,7 @@ from functions import generate_html_file, get_bugs_dict, \
 	get_other_blockers, percent
 
 
-def run_report(config, blockers, server, header, test_email, no_email, template_file):
+def run_report(config, blockers, preamble_file, server, header, test_email, no_email, template_file):
 
 	# fetch all relevant jobs
 	jobs = get_jenkins_jobs(server, config['job_search_fields'])
@@ -255,6 +255,12 @@ def run_report(config, blockers, server, header, test_email, no_email, template_
 	else:
 		summary['total_error'] = False
 
+	# load a preamble for injection if specified
+	preamble = None
+	if preamble_file:
+		with open(preamble_file, 'r') as file:
+			preamble = file.read()
+
 	# initialize jinja2 vars
 	loader = jinja2.FileSystemLoader('./templates')
 	env = jinja2.Environment(loader=loader)
@@ -267,6 +273,7 @@ def run_report(config, blockers, server, header, test_email, no_email, template_
 	# generate HTML report
 	htmlcode = template.render(
 		header=header,
+		preamble=preamble,
 		rows=rows,
 		summary=summary
 	)

--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -10,6 +10,9 @@
 				<p style="text-align: center; font-size: smaller;">Filtered job builds by parameter name {{header.fpn}} with value {{header.fpv}}</p>
 			{% endif %}
 		</div>
+		{% if preamble is not none %}
+			<pre>{{ preamble }}</pre>
+		{% endif %}
 		<div>
 			<table>
 				<tr>


### PR DESCRIPTION
Fixes #169 

Some notes:
- I've referring to this internally as a "preamble" instead of a "summary" for now as "summary" is being used for statistics (these names can change later)
- Due to how the `blockers` file is parsed and in the interest of not affecting current implementations, I've implemented the preamble inclusion as a separate HTML file entirely - whatever is present in the specified preamble file will be injected directly into the report. Not including a preamble flag will result in no change in functionality for users who wish not to use the new feature.