### PR TITLE
Add total coverage metric in summary

### DIFF
--- a/jeeves/blockers.py
+++ b/jeeves/blockers.py
@@ -152,9 +152,7 @@ def get_other_blockers(blockers, job_name):
 		returns list of 'other' blockers
 	'''
 	other = []
-	other_blockers = blockers[job_name].get('other')
-	if other_blockers is None:
-		return other
+	other_blockers = blockers[job_name]['other']
 	for blocker in other_blockers:
 		other.append({'other_name': blocker.get('name', 'Link'), 'other_url': blocker.get('url', None)})
 	return other

--- a/jeeves/report.py
+++ b/jeeves/report.py
@@ -170,7 +170,7 @@ def run_report(config, blockers, preamble_file, template_file, no_email, test_em
 	summary['total_success'] = "Total SUCCESS:  {}/{} = {}%".format(num_success, num_jobs, percent(num_success, num_jobs))
 	summary['total_unstable'] = "Total UNSTABLE: {}/{} = {}%".format(num_unstable, num_jobs, percent(num_unstable, num_jobs))
 	summary['total_failure'] = "Total FAILURE:  {}/{} = {}%".format(num_failure, num_jobs, percent(num_failure, num_jobs))
-	summary['total_coverage'] = "Total bz/jira/other coverage:  {}/{} = {}%".format(num_covered, num_jobs - num_success, percent(num_covered, num_jobs - num_success))
+	summary['total_coverage'] = "Total Blocker Coverage:  {}/{} = {}%".format(num_covered, num_jobs - num_success, percent(num_covered, num_jobs - num_success))
 
 	# Map color codes with job count and type
 	jobs_dict = {

--- a/jeeves/report.py
+++ b/jeeves/report.py
@@ -46,6 +46,7 @@ def run_report(config, blockers, preamble_file, server, header, test_email, no_e
 	num_missing = 0
 	num_aborted = 0
 	num_error = 0
+	num_covered = 0
 	rows = []
 	all_bugs = []
 	all_tickets = []
@@ -84,12 +85,14 @@ def run_report(config, blockers, preamble_file, server, header, test_email, no_e
 					num_missing += 1
 
 				# get all related bugs to job
+				job_covered = False
 				try:
 					bug_ids = blockers[job_name]['bz']
 					if 0 in bug_ids:
 						bug_ids.remove(0)
 					all_bugs.extend(bug_ids)
 					bugs = list(map(all_bugs_dict.get, bug_ids))
+					job_covered = True
 				except Exception as e:
 					print("Error fetching bugs for job {}: {}".format(job_name, e))
 					bugs = []
@@ -101,6 +104,7 @@ def run_report(config, blockers, preamble_file, server, header, test_email, no_e
 						ticket_ids.remove(0)
 					all_tickets.extend(ticket_ids)
 					tickets = list(map(all_tickets_dict.get, ticket_ids))
+					job_covered = True
 				except Exception as e:
 					print("Error fetching tickets for job {}: {}".format(job_name, e))
 					tickets = []
@@ -108,10 +112,13 @@ def run_report(config, blockers, preamble_file, server, header, test_email, no_e
 				# get any "other" artifact for job
 				try:
 					other = get_other_blockers(blockers, job_name)
+					job_covered = True
 				except Exception as e:
 					print("Error fetching other blockers for job {}: {}".format(job_name, e))
 					other = []
 
+				if job_covered:
+					num_covered += 1
 			else:
 				print("job {} had lcb_result {}: reporting as error job".format(job_name, jenkins_api_info['lcb_result']))
 				jenkins_api_info['lcb_result'] = "ERROR"
@@ -163,6 +170,7 @@ def run_report(config, blockers, preamble_file, server, header, test_email, no_e
 	summary['total_success'] = "Total SUCCESS:  {}/{} = {}%".format(num_success, num_jobs, percent(num_success, num_jobs))
 	summary['total_unstable'] = "Total UNSTABLE: {}/{} = {}%".format(num_unstable, num_jobs, percent(num_unstable, num_jobs))
 	summary['total_failure'] = "Total FAILURE:  {}/{} = {}%".format(num_failure, num_jobs, percent(num_failure, num_jobs))
+	summary['total_coverage'] = "Total bz/jira/other coverage:  {}/{} = {}%".format(num_covered, num_jobs-num_success, percent(num_covered, num_jobs-num_success))
 
 	# Map color codes with job count and type
 	jobs_dict = {

--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -36,6 +36,7 @@
 							{% endif %}
 							<li>{{summary.total_bugs}}</li>
 							<li>{{summary.total_tickets}}</li>
+							<li>{{summary.total_coverage}}</li>
 						</ul>
 					</td>
 				</tr>


### PR DESCRIPTION
This pr adds **Total FAILURE coverage** metric to the summary table.

The purpose of the metric is to show how many failing builds are not reported as jira/bz/other, in other words not tracked.