### PR TITLE
Adds pytest config, fixes flake config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,3 +2,4 @@
 ignore = E117,E501,E722,W191
 exclude =
     tests
+    python-jenkins

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+# pytest.ini
+[pytest]
+minversion = 6.0
+addopts = -ra
+testpaths =
+    tests


### PR DESCRIPTION
While I was working on my latest pull request, which  requires a latest python-jenkins package,I noticed that there is no pytest config. The result of missing pytest config is that CI checks fail not on our tests, but on tests from python-jenkins. The same 
situation is with flake checks, which needs excludes for python-jenkins.

Signed-off-by: ciecierski <mciecier@redhat.com>