### PR TITLE
Added owner name to reminder body

### DIFF
--- a/jeeves/common.py
+++ b/jeeves/common.py
@@ -61,16 +61,20 @@ def generate_summary(num_success, num_unstable, num_failure, num_aborted, num_mi
 	return summary
 
 
-def generate_html_file(htmlcode, remind=False):
-	''' generates HTML file of reminder
+def generate_html_file(htmlcode, remind=False, owner=''):
+	''' generates HTML file from given HTML code
+		if generating file for reminder, owner should be passed as well
 	'''
 	try:
 		os.makedirs('archive')
 	except FileExistsError:
 		pass
-	reportType = 'reminder' if remind else 'report'
+	owner = owner.split('@')[0]
+	reportType = 'reminder_for_{}'.format(owner) if remind else 'report'
 	filename = './archive/{}_{:%Y-%m-%d_%H-%M-%S}.html'.format(
-		reportType, datetime.datetime.now())
+		reportType,
+		datetime.datetime.now()
+	)
 	with open(filename, 'w') as file:
 		file.write(htmlcode)
 	return filename

--- a/jeeves/remind.py
+++ b/jeeves/remind.py
@@ -130,6 +130,7 @@ def run_remind(config, blockers, server, header):
 			# generate HTML report
 			htmlcode = template.render(
 				header=header,
+				owner=owner,
 				rows=rows
 			)
 

--- a/jeeves/remind.py
+++ b/jeeves/remind.py
@@ -162,7 +162,7 @@ def run_remind(config, blockers, server, header):
 
 			except Exception as e:
 				print("Error sending email reminder: {}\nHTML file generated".format(e))
-				generate_html_file(htmlcode, remind=True)
+				generate_html_file(htmlcode, remind=True, owner=owner)
 
 		else:
 			print("Owner {} has all passing jobs!".format(owner))

--- a/templates/remind_template.html
+++ b/templates/remind_template.html
@@ -9,7 +9,7 @@
 			{% if header.fpn is not none and header.fpv is not none %}
 				<p style="text-align: center; font-size: smaller;">Filtered job builds by parameter name {{header.fpn}} with value {{header.fpv}}</p>
 			{% endif %}
-			<p style="text-align: center;">Attention user, the following jobs are currently failing in CI. Please ensure each job listed has up-to-date blockers.</p>
+			<p style="text-align: center;">Attention {{owner}}, the following jobs are currently failing in CI. Please ensure each job listed has up-to-date blockers.</p>
 		</div>
 		<div>
 			<table border="1">


### PR DESCRIPTION
If a reminder fails an HTML file is generated, however at present it is impossible to tell which generated file is meant for which recipient. Minor change that directly addresses job owner rather than generic "user".