### PR TITLE
Extend filtering mechanism with build cause action filter

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -3,6 +3,7 @@ jenkins_url: https://myjenkins.ourcorporate.com
 job_search_fields: my-job-prefix-or-regex
 filter_param_name: PUBLISH_TO_POLARION
 filter_param_value: True
+cause_action_class: timer
 bz_url: https://bugzilla.ourcorporate.com
 jira_url: https://jira.ourcorporate.com
 jira_username: user1

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Create a file named `config.yaml` based off `config.yaml.example` with the follo
 - **job_search_fields**: Filter of Jenkins Jobs to included in report, e.g. DFG-ceph-rhos. To search for multiple fields, seperate them by comma, e.g. DFG-ceph-rhos,DFG-all-unified. Allows for regex searches as well, e.g. ^DFG-ceph,rgw$
 - **filter_param_name**: Optional field that instructs Jeeves to skip any build that lacks the corresponding value of the given build parameter. Must be used on in conjunction with **filter_param_value**
 - **filter_param_value**: Optional field that instructs Jeeves to skip any build that lacks this value for the corresponding build parameter name. Must be used in conjunction with **filter_param_name**
-**cause_action_class**: Optional field that instructs Jeeves to skip any build that not satisfies cause action, which started job build. Possible values are: timer, user, upstream
+**cause_action_class**: Optional field that instructs Jeeves to skip any build that not satisfies 'cause action', which started a job build. Possible values are: timer, user or upstream
 - **bz_url**: URL of your Bugzilla, e.g. https://bugzilla.redhat.com/
 - **jira_url**: URL of your Jira, e.g. https://projects.engineering.redhat.com/
 - **jira_username**: Your Jira username

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Create a file named `config.yaml` based off `config.yaml.example` with the follo
 - **job_search_fields**: Filter of Jenkins Jobs to included in report, e.g. DFG-ceph-rhos. To search for multiple fields, seperate them by comma, e.g. DFG-ceph-rhos,DFG-all-unified. Allows for regex searches as well, e.g. ^DFG-ceph,rgw$
 - **filter_param_name**: Optional field that instructs Jeeves to skip any build that lacks the corresponding value of the given build parameter. Must be used on in conjunction with **filter_param_value**
 - **filter_param_value**: Optional field that instructs Jeeves to skip any build that lacks this value for the corresponding build parameter name. Must be used in conjunction with **filter_param_name**
+**cause_action_class**: Optional field that instructs Jeeves to skip any build that not satisfies cause action, which started job build. Possible values are: timer, user, upstream
 - **bz_url**: URL of your Bugzilla, e.g. https://bugzilla.redhat.com/
 - **jira_url**: URL of your Jira, e.g. https://projects.engineering.redhat.com/
 - **jira_username**: Your Jira username

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Create a file named `config.yaml` based off `config.yaml.example` with the follo
 - **job_search_fields**: Filter of Jenkins Jobs to included in report, e.g. DFG-ceph-rhos. To search for multiple fields, seperate them by comma, e.g. DFG-ceph-rhos,DFG-all-unified. Allows for regex searches as well, e.g. ^DFG-ceph,rgw$
 - **filter_param_name**: Optional field that instructs Jeeves to skip any build that lacks the corresponding value of the given build parameter. Must be used on in conjunction with **filter_param_value**
 - **filter_param_value**: Optional field that instructs Jeeves to skip any build that lacks this value for the corresponding build parameter name. Must be used in conjunction with **filter_param_name**
-**cause_action_class**: Optional field that instructs Jeeves to skip any build that not satisfies 'cause action', which started a job build. Possible values are: timer, user or upstream
+**cause_action_class**: Optional field that instructs Jeeves to skip any build that does not satisfy the 'cause action' which started a job build. Possible values are: timer, user, or upstream
 - **bz_url**: URL of your Bugzilla, e.g. https://bugzilla.redhat.com/
 - **jira_url**: URL of your Jira, e.g. https://projects.engineering.redhat.com/
 - **jira_username**: Your Jira username

--- a/jeeves/remind.py
+++ b/jeeves/remind.py
@@ -27,6 +27,7 @@ def run_remind(config, blockers, server, header):
 	# fetch optional config options, return None if not present
 	fpn = config.get('filter_param_name', None)
 	fpv = config.get('filter_param_value', None)
+	cac = config.get('cause_action_class', None)
 
 	# find each job with no blockers including the owner and send email with agg'd list
 	owner_set = set(owner_list)
@@ -41,7 +42,7 @@ def run_remind(config, blockers, server, header):
 				continue
 
 			# get job info from jenkins API - will return False if an unmanageable error occured
-			jenkins_api_info = get_jenkins_job_info(server, job_name, filter_param_name=fpn, filter_param_value=fpv)
+			jenkins_api_info = get_jenkins_job_info(server, job_name, filter_param_name=fpn, filter_param_value=fpv, cause_action_class=cac)
 
 			# if jeeves was unable to collect any good jenkins API info, skip job
 			if jenkins_api_info:

--- a/jeeves/report.py
+++ b/jeeves/report.py
@@ -40,6 +40,7 @@ def run_report(config, blockers, preamble_file, template_file, no_email, test_em
 	# fetch optional config options, return None if not present
 	fpn = config.get('filter_param_name', None)
 	fpv = config.get('filter_param_value', None)
+	cac = config.get('cause_action_class', None)
 
 	# iterate through all relevant jobs and build report rows
 	num_success = 0
@@ -76,7 +77,7 @@ def run_report(config, blockers, preamble_file, template_file, no_email, test_em
 			}
 
 		# get job info from jenkins API - will return False if an unmanageable error occured
-		jenkins_api_info = get_jenkins_job_info(server, job_name, filter_param_name=fpn, filter_param_value=fpv)
+		jenkins_api_info = get_jenkins_job_info(server, job_name, filter_param_name=fpn, filter_param_value=fpv, cause_action_class=cac)
 
 		# if jeeves was unable to collect any good jenkins api info, skip job
 		if jenkins_api_info:


### PR DESCRIPTION
This pr adds new build filter option. It enables to filter jobs by hudson.model.CauseAction field. 
This field contains information who triggered build. It can by either timer,user or other jenkins job(upstream).
It can be used in combination of existing param filter mechanism.

Signed-off-by: ciecierski <mciecier@redhat.com>