### PR TITLE
Add the build number to the blocker definition.

### DIFF
--- a/blockers.yaml.example
+++ b/blockers.yaml.example
@@ -12,6 +12,8 @@ job2:
     jira:
         - 'RHOSINFRA-456'
         - 'RHOSINFRA-789'
+    builds:
+        - 2,3
 
 # 0 indicates blocker bug/ticket is not on file (either doesn't exist or hasn't been created yet)
 job3:
@@ -41,6 +43,15 @@ job5:
     other:
         - name: Experimental Job
         - url: <URL>
+
+# You can have build number for blockers included in report
+job5:
+    bz:
+        - 0
+    jira:
+        - 'RHOSINFRA-753'
+    builds:
+        - 2,3
 
 # If you wish for a job to have an owner, you can specify this as follows
 job6:

--- a/blockers.yaml.example
+++ b/blockers.yaml.example
@@ -64,7 +64,7 @@ job7:
     jira:
         - 0
 
-# You can have build number for blockers included in report
+# You can have build numbers for blockers included in report
 job8:
     bz:
         - 1

--- a/blockers.yaml.example
+++ b/blockers.yaml.example
@@ -13,7 +13,8 @@ job2:
         - 'RHOSINFRA-456'
         - 'RHOSINFRA-789'
     builds:
-        - 2,3
+        - 2
+        - 3
 
 # 0 indicates blocker bug/ticket is not on file (either doesn't exist or hasn't been created yet)
 job3:
@@ -44,15 +45,6 @@ job5:
         - name: Experimental Job
         - url: <URL>
 
-# You can have build number for blockers included in report
-job5:
-    bz:
-        - 0
-    jira:
-        - 'RHOSINFRA-753'
-    builds:
-        - 2,3
-
 # If you wish for a job to have an owner, you can specify this as follows
 job6:
     owners:
@@ -71,3 +63,13 @@ job7:
         - 852
     jira:
         - 0
+
+# You can have build number for blockers included in report
+job8:
+    bz:
+        - 1
+    jira:
+        - 'RHOSINFRA-754'
+    builds:
+        - 1
+        - 3

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ If you wish to use a different configuration file, you can specify it as a comma
 #### Tracking Blockers
 Create a file named `blockers.yaml` based off `blockers.yaml.example` with each UNSTABLE and FAILED job containing two sections - 'bz' and 'jira' - and a list of the blocker IDs. 0 indicates blocker bug/ticket is not on file (either doesn't exist or hasn't been created yet).
 
-If you have a blocker for a job that is neither a Bugzilla bug or a Jira ticket, you may add a section to your blockers file called 'other', with each item having two fields - 'name' and 'url'. Both fields are optional - you can include one, the other, or both. You can also add information about build number for FAILED and UNSTABLE builds.
+If you have a blocker for a job that is neither a Bugzilla bug or a Jira ticket, you may add a section to your blockers file called 'other', with each item having two fields - 'name' and 'url'. Both fields are optional - you can include one, the other, or both. You can also add information about build number for FAILED, UNSTABLE,and NO_KNOWN_BUILDS builds.
 
 If you wish to use a different blockers file, you can specify it as a command line argument.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ If you wish to use a different configuration file, you can specify it as a comma
 #### Tracking Blockers
 Create a file named `blockers.yaml` based off `blockers.yaml.example` with each UNSTABLE and FAILED job containing two sections - 'bz' and 'jira' - and a list of the blocker IDs. 0 indicates blocker bug/ticket is not on file (either doesn't exist or hasn't been created yet).
 
+If you have a blocker for a job that is neither a Bugzilla bug or a Jira ticket, you may add a section to your blockers file called 'other', with each item having two fields - 'name' and 'url'. Both fields are optional - you can include one, the other, or both.
 You can also add information about build number for FAILED, UNSTABLE, and NO_KNOWN_BUILDS builds.
 
 If you wish to use a different blockers file, you can specify it as a command line argument.

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,9 @@ If you wish to use a different configuration file, you can specify it as a comma
 Create a file named `blockers.yaml` based off `blockers.yaml.example` with each UNSTABLE and FAILED job containing two sections - 'bz' and 'jira' - and a list of the blocker IDs. 0 indicates blocker bug/ticket is not on file (either doesn't exist or hasn't been created yet).
 
 If you have a blocker for a job that is neither a Bugzilla bug or a Jira ticket, you may add a section to your blockers file called 'other', with each item having two fields - 'name' and 'url'. Both fields are optional - you can include one, the other, or both.
+
 You can also add information about build number for FAILED, UNSTABLE, and NO_KNOWN_BUILDS builds.
+If you record the build number for which you have registered the issue, then you can speed up the review process by knowing if that ticket is still "current". This can be very helpful when a build starts to work again, but the blocker file is not updated. Then next time it fails, the last issue registered for that job pops up again. It can take you some time to figure out that it's not relevant anymore. But if you have build number, then you see "99" as your current build number and that the issue was registered to build "80" then you are pretty sure it's outdated.
 
 If you wish to use a different blockers file, you can specify it as a command line argument.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ If you wish to use a different configuration file, you can specify it as a comma
 #### Tracking Blockers
 Create a file named `blockers.yaml` based off `blockers.yaml.example` with each UNSTABLE and FAILED job containing two sections - 'bz' and 'jira' - and a list of the blocker IDs. 0 indicates blocker bug/ticket is not on file (either doesn't exist or hasn't been created yet).
 
-If you have a blocker for a job that is neither a Bugzilla bug or a Jira ticket, you may add a section to your blockers file called 'other', with each item having two fields - 'name' and 'url'. Both fields are optional - you can include one, the other, or both. You can also add information about build number for FAILED, UNSTABLE,and NO_KNOWN_BUILDS builds.
+You can also add information about build number for FAILED, UNSTABLE, and NO_KNOWN_BUILDS builds.
 
 If you wish to use a different blockers file, you can specify it as a command line argument.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Create a file named `config.yaml` based off `config.yaml.example` with the follo
 - **job_search_fields**: Filter of Jenkins Jobs to included in report, e.g. DFG-ceph-rhos. To search for multiple fields, seperate them by comma, e.g. DFG-ceph-rhos,DFG-all-unified. Allows for regex searches as well, e.g. ^DFG-ceph,rgw$
 - **filter_param_name**: Optional field that instructs Jeeves to skip any build that lacks the corresponding value of the given build parameter. Must be used on in conjunction with **filter_param_value**
 - **filter_param_value**: Optional field that instructs Jeeves to skip any build that lacks this value for the corresponding build parameter name. Must be used in conjunction with **filter_param_name**
-**cause_action_class**: Optional field that instructs Jeeves to skip any build that does not satisfy the 'cause action' which started a job build. Possible values are: timer, user, or upstream
+- **cause_action_class**: Optional field that instructs Jeeves to skip any build that does not satisfy the 'cause action' which started a job build. Possible values are: timer, user, or upstream
 - **bz_url**: URL of your Bugzilla, e.g. https://bugzilla.redhat.com/
 - **jira_url**: URL of your Jira, e.g. https://projects.engineering.redhat.com/
 - **jira_username**: Your Jira username
@@ -31,7 +31,7 @@ If you wish to use a different configuration file, you can specify it as a comma
 #### Tracking Blockers
 Create a file named `blockers.yaml` based off `blockers.yaml.example` with each UNSTABLE and FAILED job containing two sections - 'bz' and 'jira' - and a list of the blocker IDs. 0 indicates blocker bug/ticket is not on file (either doesn't exist or hasn't been created yet).
 
-If you have a blocker for a job that is neither a Bugzilla bug or a Jira ticket, you may add a section to your blockers file called 'other', with each item having two fields - 'name' and 'url'. Both fields are optional - you can include one, the other, or both.
+If you have a blocker for a job that is neither a Bugzilla bug or a Jira ticket, you may add a section to your blockers file called 'other', with each item having two fields - 'name' and 'url'. Both fields are optional - you can include one, the other, or both. You can also add information about build number for FAILED and UNSTABLE builds.
 
 If you wish to use a different blockers file, you can specify it as a command line argument.
 

--- a/jeeves/remind.py
+++ b/jeeves/remind.py
@@ -84,7 +84,7 @@ def run_remind(config, blockers, server, header):
 					if (len(bugs) == 0) and (len(tickets) == 0) and (len(other) == 0):
 						blocker_bool = False
 
-					# check if row conatians build number information
+					# check if row contains build number information
 					builds = None
 					if job_name in blockers and 'builds' in blockers[job_name]:
 						builds = blockers[job_name]['builds']

--- a/jeeves/remind.py
+++ b/jeeves/remind.py
@@ -84,6 +84,11 @@ def run_remind(config, blockers, server, header):
 					if (len(bugs) == 0) and (len(tickets) == 0) and (len(other) == 0):
 						blocker_bool = False
 
+					# check if row conatians build number information
+					builds = None
+					if job_name in blockers and 'builds' in blockers[job_name]:
+						builds = blockers[job_name]['builds']
+
 					stage_urls = []
 					if jenkins_api_info['stage_failure'] != 'N/A':
 						stage_urls = generate_failure_stage_log_urls(
@@ -108,6 +113,7 @@ def run_remind(config, blockers, server, header):
 						'bugs': bugs,
 						'tickets': tickets,
 						'other': other,
+						'builds': builds,
 						'tempest_tests_failed': jenkins_api_info['tempest_tests_failed'],
 						'tempest_tests_url': jenkins_api_info['job_url'] + str(jenkins_api_info['lcb_num']) + '/testReport',
 						'stage_name': jenkins_api_info['stage_failure'],

--- a/jeeves/report.py
+++ b/jeeves/report.py
@@ -151,6 +151,11 @@ def run_report(config, blockers, preamble_file, template_file, no_email, test_em
 			if (len(bugs) == 0) and (len(tickets) == 0) and (len(other) == 0):
 				blocker_bool = False
 
+			# check if row conatians build number information
+			builds = None
+			if job_name in blockers and 'builds' in blockers[job_name]:
+				builds = blockers[job_name]['builds']
+
 			stage_urls = []
 			if jenkins_api_info['stage_failure'] != 'N/A':
 				stage_urls = generate_failure_stage_log_urls(
@@ -175,6 +180,7 @@ def run_report(config, blockers, preamble_file, template_file, no_email, test_em
 				'bugs': bugs,
 				'tickets': tickets,
 				'other': other,
+				'builds': builds,
 				'tempest_tests_failed': jenkins_api_info['tempest_tests_failed'],
 				'tempest_tests_url': jenkins_api_info['job_url'] + str(jenkins_api_info['lcb_num']) + '/testReport',
 				'stage_name': jenkins_api_info['stage_failure'],

--- a/jeeves/report.py
+++ b/jeeves/report.py
@@ -151,7 +151,7 @@ def run_report(config, blockers, preamble_file, template_file, no_email, test_em
 			if (len(bugs) == 0) and (len(tickets) == 0) and (len(other) == 0):
 				blocker_bool = False
 
-			# check if row conatians build number information
+			# check if row contains build number information
 			builds = None
 			if job_name in blockers and 'builds' in blockers[job_name]:
 				builds = blockers[job_name]['builds']

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -3,11 +3,14 @@
 		<p style="text-align: center;"><b>Bugs</b></p>
 		{% for bug in row.bugs %}
 			<ul>
-			{% if bug.bug_url != None %}
-				<li><a href="{{bug.bug_url}}">{{bug.bug_name}}</a></li>
-			{% else %}
-				<li>{{bug.bug_name}}</li>
-			{% endif %}
+				<li>
+				{% if bug.bug_url != None %}
+					<a href="{{bug.bug_url}}">{{bug.bug_name}}</a>
+				{% else %}
+					{{bug.bug_name}}
+				{% endif %}
+				{{ build_numbers(row) }}
+				</li>
 			</ul>
 		{% endfor %}
 		{% if row.tickets|length > 0 or row.other|length > 0%}
@@ -18,11 +21,14 @@
 		<p style="text-align: center;"><b>Tickets</b></p>
 		{% for ticket in row.tickets %}
 			<ul>
-			{% if ticket.ticket_url != None %}
-				<li><a href="{{ticket.ticket_url}}">{{ticket.ticket_name}}</a></li>
-			{% else %}
-				<li>{{ticket.ticket_name}}</li>
-			{% endif %}
+				<li>
+				{% if ticket.ticket_url != None %}
+					<a href="{{ticket.ticket_url}}">{{ticket.ticket_name}}</a>
+				{% else %}
+					{{ticket.ticket_name}}
+				{% endif %}
+				{{ build_numbers(row) }}
+				</li>
 			</ul>
 		{% endfor %}
 		{% if row.other|length > 0%}
@@ -33,12 +39,25 @@
 		<p style="text-align: center;"><b>Other</b></p>
 		{% for other in row.other %}
 			<ul>
-			{% if other.other_url != None %}
-				<li><a href="{{other.other_url}}">{{other.other_name}}</a></li>
-			{% else %}
-				<li>{{other.other_name}}</li>
-			{% endif %}
+				<li>
+				{% if other.other_url != None %}
+					<a href="{{other.other_url}}">{{other.other_name}}</a>
+				{% else %}
+					{{other.other_name}}
+				{% endif %}
+				{{ build_numbers(row) }}
+				</li>
 			</ul>
+		{% endfor %}
+	{% endif %}
+{% endmacro %}
+
+{% macro build_numbers(row) %}
+	{% if row.builds is defined and row.builds is not none %}
+		: for build
+		{% for build in row.builds %}
+			<a href="{{row.job_url}}/{{ build }}">{{ build }}</a>
+			{{ ", " if not loop.last }}
 		{% endfor %}
 	{% endif %}
 {% endmacro %}


### PR DESCRIPTION
When filling out the blocker structure, one can add the "builds" field so that it's easy to know if the current issue is still relevant.
Signed-off-by: ciecierski <mciecier@redhat.com>