### PR TITLE
Added Personal Access Tokens authentication for jira authentication

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -6,8 +6,12 @@ filter_param_value: True
 cause_action_class: timer
 bz_url: https://bugzilla.ourcorporate.com
 jira_url: https://jira.ourcorporate.com
-jira_username: user1
-jira_password: coolpassword
+# Use one of two options to authenticate to jira
+# Using Personal Access Token is preferred, to use
+# Basic Authentication uncomment jira_username and jira_password
+#jira_username: user1
+#jira_password: coolpassword
+jira_token: personalaccesstoken
 certificate: our_jira_cert.crt
 smtp_host: smtp.ourcorporate.com
 email_subject: Our CI status report

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,9 @@ Create a file named `config.yaml` based off `config.yaml.example` with the follo
 - **cause_action_class**: Optional field that instructs Jeeves to skip any build that does not satisfy the 'cause action' which started a job build. Possible values are: timer, user, or upstream
 - **bz_url**: URL of your Bugzilla, e.g. https://bugzilla.redhat.com/
 - **jira_url**: URL of your Jira, e.g. https://projects.engineering.redhat.com/
-- **jira_username**: Your Jira username
-- **jira_password**: Your Jira password
+- **jira_username**: Your Jira username. If included in config.yaml basic auth method is used to authenticate to jira, otherwise Personal Access Token is used and jira_token has to be set.
+- **jira_password**: Your Jira password. Has to be set together with jira_username field.
+- **jira_token**: Your Jira Personal Access Token.
 - **certificate**: CRT file to authenticate with Jira server
 - **smtp_host**: SMTP host of your email
 - **email_subject**: Subject of your email report

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyyaml==6.0
 jinja2==3.0.3
 python-jenkins==1.8.0.0a0
 python-bugzilla==3.1.0
-jira==3.0.1
+jira==3.1.1
 pytest==6.2.5
 pytest-cov==3.0.0
 flake8==4.0.1


### PR DESCRIPTION
This change introduces Personal Access Tokens authentication for jira
to get tickets for blockers. It will be possible to choose what
type of authentication method jeeves should use by setting jira_*
fields accordingly.

What changed:
- Bumped jira from 3.0.1 to 3.1.1, which introduced Personal Access
Tokens auth method
- New Personal Access Token auth method in blockers file introduced
next to Basic Auth method.