### PR TITLE
Skip build number info when job doesn't have blockers reported

### DIFF
--- a/jeeves/remind.py
+++ b/jeeves/remind.py
@@ -84,9 +84,9 @@ def run_remind(config, blockers, server, header):
 					if (len(bugs) == 0) and (len(tickets) == 0) and (len(other) == 0):
 						blocker_bool = False
 
-					# check if row contains build number information
+					# check if row contains build number information if blocker is added
 					builds = None
-					if job_name in blockers and 'builds' in blockers[job_name]:
+					if blocker_bool and job_name in blockers and 'builds' in blockers[job_name]:
 						builds = blockers[job_name]['builds']
 
 					stage_urls = []

--- a/jeeves/report.py
+++ b/jeeves/report.py
@@ -151,9 +151,9 @@ def run_report(config, blockers, preamble_file, template_file, no_email, test_em
 			if (len(bugs) == 0) and (len(tickets) == 0) and (len(other) == 0):
 				blocker_bool = False
 
-			# check if row contains build number information
+			# check if row contains build number information if blocker is added
 			builds = None
-			if job_name in blockers and 'builds' in blockers[job_name]:
+			if blocker_bool and job_name in blockers and 'builds' in blockers[job_name]:
 				builds = blockers[job_name]['builds']
 
 			stage_urls = []


### PR DESCRIPTION
Don't check for buld number of a job, when there is no valid blocker
reported. This also solves problem with jeeves fails on generating
report when blockers file is empty.