### PR TITLE
Move test requirements.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r test-requirements.txt
       - name: Test with pytest
         run: |
           pytest

--- a/jeeves/jobs.py
+++ b/jeeves/jobs.py
@@ -187,6 +187,7 @@ def get_osp_version(job_name, filter_version=None):
 
 	if not versions:
 		return None
+
 	versions_f = map(float, versions)
 	max_value = max(versions_f)
 	return '{:g}'.format(max_value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,4 @@ jinja2==3.0.3
 python-jenkins==1.8.0.0a0
 python-bugzilla==3.2.0
 jira==3.1.1
-pytest==7.1.1
-pytest-cov==3.0.0
 flake8==4.0.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==7.1.1
+pytest-cov==3.0.0


### PR DESCRIPTION
Move the test requirements in a specific file. An end user does not need
to install test dependecies. The pytest dependency has been updated and requires python 3.7 or higher. There are distributions that still package
python 3.6.